### PR TITLE
[PRO-926] test workflow changes to make failures ping openhands

### DIFF
--- a/.github/workflows/openhands-resolver.yml
+++ b/.github/workflows/openhands-resolver.yml
@@ -41,6 +41,16 @@ permissions:
 
 jobs:
 
+  debug-authorization:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug Authorization
+        if: github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment'
+        run: |
+          echo "Event type: ${{ github.event_name }}"
+          echo "Comment starts with @openhands-agent: ${{ startsWith(github.event.comment.body, '@openhands-agent') }}"
+          echo "Author association: ${{ github.event.comment.author_association }}"
+
   auto-fix:
     if: |
       github.event_name == 'workflow_call' ||

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,6 +223,8 @@ jobs:
 
   # notify openhands to try again if there's a failure with a retry limit
   notify-openhands:
+    permissions:
+      pull-requests: write
     needs: [e2etest, authenticated-e2etest, unit-test]
     runs-on: ubuntu-latest
     if: failure() && github.event_name == 'pull_request'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - main
+
 env:
   RECORD_REPLAY_API_KEY: rwk_yaEG8jo6gcisGHHoMj8SNoOMIHSbT7REuU5E1QnKCiL
   RECORD_REPLAY_METADATA_TEST_RUN_TITLE: E2E Tests
@@ -229,6 +230,7 @@ jobs:
       - name: Check retry count
         uses: actions/github-script@v7
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const MAX_RETRIES = 3;
 
@@ -254,6 +256,7 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const message = `@openhands-agent
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,3 +218,56 @@ jobs:
           YARN_CHECKSUM_BEHAVIOR: "update"
       - name: Run tests
         run: yarn test
+
+
+  # notify openhands to try again if there's a failure with a retry limit
+  notify-openhands:
+    needs: [e2etest, authenticated-e2etest, unit-test]
+    runs-on: ubuntu-latest
+    if: failure() && github.event_name == 'pull_request'
+    steps:
+      - name: Check retry count
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const MAX_RETRIES = 3;
+
+            // Get all comments
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number
+            });
+
+            // Count retry attempts
+            const retryCount = comments.data.filter(comment =>
+              comment.body.includes('@openhands-agent') &&
+              comment.body.includes('❌ Test Failure')
+            ).length;
+
+            console.log(`Current retry count: ${retryCount}`);
+
+            if (retryCount >= MAX_RETRIES) {
+              throw new Error(`Maximum retry count (${MAX_RETRIES}) reached. Stopping workflow.`);
+            }
+
+      - name: Comment on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const message = `@openhands-agent
+
+            ❌ Test Failure
+
+            One or more checks failed.  Please review the workflow logs for details.
+
+            [View workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
+
+            If the failure was due to your change, please fix it.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: message
+            });

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,8 +223,6 @@ jobs:
 
   # notify openhands to try again if there's a failure with a retry limit
   notify-openhands:
-    permissions:
-      pull-requests: write
     needs: [e2etest, authenticated-e2etest, unit-test]
     runs-on: ubuntu-latest
     if: failure() && github.event_name == 'pull_request'
@@ -232,7 +230,7 @@ jobs:
       - name: Check retry count
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.PAT_TOKEN}}
           script: |
             const MAX_RETRIES = 3;
 
@@ -258,7 +256,7 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v7
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.PAT_TOKEN}}
           script: |
             const message = `@openhands-agent
 

--- a/rerecord.yml
+++ b/rerecord.yml
@@ -1,0 +1,31 @@
+name: Rerecord the reported issue
+
+on:
+  pull_request:
+
+jobs:
+  preview-branch:
+    name: Wait for Vercel Preview Branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Waiting for 200 from the Vercel Preview
+        uses: patrickedqvist/wait-for-vercel-preview@v1.3.1
+        id: waitFor200
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          max_timeout: 960
+          check_interval: 60
+          environment: ${{ fromJSON('["", "production"]')[github.ref == 'refs/heads/main'] }}
+    outputs:
+      url: ${{ steps.waitFor200.outputs.url }}
+  rerecord-issue:
+    name: Rerecord issue
+    runs-on: ubuntu-latest
+    needs: [preview-branch]
+    timeout-minutes: 10
+    steps:
+      - name: Rerecord issue
+        uses: replayio/action-rerecord@0.0.30
+        with:
+          api-key: ${{ secrets.RECORD_REPLAY_API_KEY }}
+          server-url: ${{ needs.preview-branch.outputs.url }}


### PR DESCRIPTION
ping @openhands-agent to retry on test failure, up to MAX_RETRIES (currently 3)