### PR TITLE
Fix issue #9: Display matched selector priority (IMPORTANT)

### DIFF
--- a/src/devtools/client/inspector/computed/actions/index.ts
+++ b/src/devtools/client/inspector/computed/actions/index.ts
@@ -105,6 +105,23 @@ export async function createComputedProperties(
               cachedParsedProperties.set(combinedNameValue, parsedValue);
             }
 
+            // Reproduction step Repro:index:
+            // outputParser has contents Object
+            // NO_RULES has contents Object
+            // NO_COMPUTEDS has contents Object
+            // properties has contents Object
+            // name has contents "color"
+            // value has contents "rgb(0, 128, 0)"
+            // inheritanceCounter has contents 1
+            // selectors has contents Object
+            // rule has contents Object
+            // selector has contents "div"
+            // stylesheet has contents "inline:5"
+            // stylesheetURL has contents ""
+            // declaration has contents Object
+            // property has contents { textProp: Object, name: "color", value: "green", priority: "important", overridden: false }
+            // combinedNameValue has contents "color:green"
+            // parsedValue has contents Object
             selectors.push({
               value: property.value,
               parsedValue,
@@ -112,6 +129,7 @@ export async function createComputedProperties(
               stylesheet,
               stylesheetURL,
               overridden: !!property.overridden,
+              important: property.priority === "important",
             });
           }
         }

--- a/src/devtools/client/inspector/computed/components/ComputedProperty.tsx
+++ b/src/devtools/client/inspector/computed/components/ComputedProperty.tsx
@@ -73,6 +73,7 @@ export default function ComputedProperty(props: ComputedPropertyProps) {
         <div className="matchedselectors">
           {isExpanded
             ? property.selectors.map((selector, index) => (
+                // Reproduction step Repro:ComputedProperty:
                 <MatchedSelector key={index} selector={selector} />
               ))
             : null}

--- a/src/devtools/client/inspector/computed/components/MatchedSelector.tsx
+++ b/src/devtools/client/inspector/computed/components/MatchedSelector.tsx
@@ -26,9 +26,6 @@ export default function MatchedSelector(props: MatchedSelectorProps) {
       <span dir="ltr" className="rule-text theme-fg-color3">
         <div className="fix-get-selection">{selector.selector}</div>
         <div className="fix-get-selection computed-other-property-value theme-fg-color1">
-          // Reproduction step Repro:MatchedSelector:
-          // the React element creation which triggered this render is at reproduction step Repro:ComputedProperty
-          // selector has contents { value: "green", parsedValue: Object, selector: "div", stylesheet: "inline:5", stylesheetURL: "", overridden: false }, which is an object created at reproduction step Repro:index
           <>
             <DeclarationValue
               colorSpanClassName="computed-color"

--- a/src/devtools/client/inspector/computed/components/MatchedSelector.tsx
+++ b/src/devtools/client/inspector/computed/components/MatchedSelector.tsx
@@ -26,12 +26,18 @@ export default function MatchedSelector(props: MatchedSelectorProps) {
       <span dir="ltr" className="rule-text theme-fg-color3">
         <div className="fix-get-selection">{selector.selector}</div>
         <div className="fix-get-selection computed-other-property-value theme-fg-color1">
-          <DeclarationValue
-            colorSpanClassName="computed-color"
-            colorSwatchClassName="computed-colorswatch"
-            fontFamilySpanClassName="computed-font-family"
-            values={selector.parsedValue}
-          />
+          // Reproduction step Repro:MatchedSelector:
+          // the React element creation which triggered this render is at reproduction step Repro:ComputedProperty
+          // selector has contents { value: "green", parsedValue: Object, selector: "div", stylesheet: "inline:5", stylesheetURL: "", overridden: false }, which is an object created at reproduction step Repro:index
+          <>
+            <DeclarationValue
+              colorSpanClassName="computed-color"
+              colorSwatchClassName="computed-colorswatch"
+              fontFamilySpanClassName="computed-font-family"
+              values={selector.parsedValue}
+            />
+            {selector.important ? " !important" : null}
+          </>
         </div>
       </span>
     </div>

--- a/src/devtools/client/inspector/computed/state/index.ts
+++ b/src/devtools/client/inspector/computed/state/index.ts
@@ -12,6 +12,7 @@ export interface MatchedSelectorState {
   overridden: boolean;
   stylesheet: string;
   stylesheetURL: string;
+  important: boolean;
 }
 
 export interface ComputedState {

--- a/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
+++ b/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
@@ -15,6 +15,8 @@ interface DeclarationValueProps {
 
 class DeclarationValue extends React.PureComponent<DeclarationValueProps> {
   render() {
+    // Reproduction step Repro:DeclarationValue:
+    // the React element creation which triggered this render is at reproduction step Repro:MatchedSelector
     return this.props.values.map(v => {
       if (typeof v === "string") {
         return v;


### PR DESCRIPTION
This pull request fixes #9.

While the AI agent has described making changes that seem relevant to the issue, there are several problems with verifying the resolution:

1. No actual code changes were shown in the response - just descriptions of intended changes. Without seeing the specific code modifications, we cannot verify if the implementation is correct.

2. The issue description references a recording link (replay.io) which the agent didn't mention reviewing. This recording likely contains important context about the exact problem that needs to be fixed.

3. The issue mentions specific source comments labeled "Repro:MatchedSelector" that should be used to understand the problem, but the agent didn't reference finding or using these comments.

4. There's no confirmation that the changes were tested or that the reproduction steps now show the correct "!important" behavior.

To properly resolve this issue, the agent should:
1. Review the replay recording
2. Locate and examine the "Repro:MatchedSelector" comments
3. Show the actual code changes being made
4. Confirm the changes fix the issue through testing

Without these elements, we cannot consider the issue successfully resolved.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌